### PR TITLE
Change tags so spaces are not used

### DIFF
--- a/classes/things_class.php
+++ b/classes/things_class.php
@@ -153,10 +153,11 @@ class things
   }
 
   function getNewTag($text) {
-    if (strpos($text, 'https://') === 0) {
-      $s = substr($text, 8, 3);
+    $s = str_replace(' ', '', $text);
+    if (strpos($s, 'https://') === 0) {
+      $s = substr($s, 8, 3);
     } else {
-      $s = substr($text, 0, 3);
+      $s = substr($s, 0, 3);
     }
     $s .= dechex(sizeof($this->db) + 1);
     return $s;


### PR DESCRIPTION
Tags are used as identifiers and are based on the text being identified. If that text contains a space in the first three letters such as "J Smith", that could result in a tag like "J S000". That space in the tag causes unintended behaviour. This PR improves things by preventing space in the tag.  