### PR TITLE
Correct behaviour whereby cancelling a search causes a loop

### DIFF
--- a/search.php
+++ b/search.php
@@ -34,9 +34,10 @@ $dialog_question->sizes_change(MENU_SZ_SHORT);
 $dialog_question->input = 'Search on what name?';
 $search_phrase = $dialog_question->show();
 
-if ($search_phrase === "") {
+if ($search_phrase === '') {
   // cancelled
   $thing_tag = $effort->wereLookingAt();
+  $effort->whatToShowNext($thing_tag);
 
 } else {
   // search on that phrase
@@ -111,8 +112,9 @@ if ($search_phrase === "") {
   $dialog_found->sizes_change(MENU_SZ_LONG);
   $output = $dialog_found->show();
 
-  if ($output === "") {
+  if ($output === '') {
     $thing_tag = $effort->wereLookingAt();
+    $effort->whatToShowNext($thing_tag);
 
   } else {
     // what got chosen?


### PR DESCRIPTION
search-cancel-loop
To replicate:
Start or.sh and from Top Level search on the current epoch 
time (eg, 1595344722. 
  Reason being that epoch time unlikely to be a Thing)
Search will respond No Matches Found
Tab to Cancel - we do NOT want to search again
Press return 
SHOULD return us to Top Level
INSTEAD returns us to Search
