### PR TITLE
better-handling-cancel

### DIFF
--- a/add-aka.php
+++ b/add-aka.php
@@ -33,6 +33,12 @@ $dialog_search->sizes_change(MENU_SZ_SHORT);
 $dialog_search->input = 'Which tag should be an AKA?';
 $search_phrase = $dialog_search->show();
 
+if ($search_phrase === '') {
+  $tag = $effort->wereLookingAt();
+  $effort->whatToShowNext($tag);
+  return;
+}
+
 $things = new things($projname);
 $things->load();
 $found_arr = array();

--- a/add-link.php
+++ b/add-link.php
@@ -33,6 +33,12 @@ $dialog_search->sizes_change(MENU_SZ_SHORT);
 $dialog_search->input = 'Search/Add on what name?';
 $search_phrase = $dialog_search->show();
 
+if ($search_phrase === '') {
+  $tag = $effort->wereLookingAt();
+  $effort->whatToShowNext($tag);
+  return;
+}
+
 // Establish what might match the user's input
 $things = new things($projname);
 $things->load();
@@ -87,8 +93,9 @@ $dialog_found->menu = $thing_text;
 $output = $dialog_found->show();
 
 if ($output === '') {
-  print_r("Cancelled");
-  exit;
+  $tag = $effort->wereLookingAt();
+  $effort->whatToShowNext($tag);
+  return;
 }
 
 // what got chosen?

--- a/add-review.php
+++ b/add-review.php
@@ -32,6 +32,9 @@ $dialog->sizes_change(MENU_SZ_SHORT);
 $dialog->edit = $tempfile;
 $review_text = trim($dialog->show());
 
-shell_exec("php api/review_add.php \"$projname\" \"$review_ts\" \"$uploader\" \"$review_text\" \"$record_to_show\"");
+if ($review_text !== '') {
+  shell_exec("php api/review_add.php \"$projname\" \"$review_ts\" " .
+	     "\"$uploader\" \"$review_text\" \"$record_to_show\"");
+}
 $effort->whatToShowNext($record_to_show);
 ?>

--- a/classes/dialog_common.php
+++ b/classes/dialog_common.php
@@ -20,6 +20,7 @@ class dialog
   public $input_init = '';
   public $menu = '';
   public $msg = '';
+  public $show_cancel = true;
   public $sizes = MENU_SZ_LONG;
   public $title = '';
 
@@ -43,6 +44,9 @@ class dialog
 	$cmd .= "'" . $this->escape($this->input_init) . "' ";
 
     } elseif ($this->menu !== '') {
+      if ($this->show_cancel === false) {
+	$cmd .= '--nocancel ';
+      }
       $cmd .= "--menu '" . $this->escape($this->menu) . "' " .
 	$this->escape($this->sizes) . " " . $this->choices;
 

--- a/edit-nuance.php
+++ b/edit-nuance.php
@@ -50,9 +50,10 @@ $dialog->sizes_change(MENU_SZ_SHORT);
 $dialog->input = 'Edit new nuance ';
 $thing_name = $dialog->show();
 
-// store the edited name
-$things->db[$record_idx]->nuance($thing_name);
-$things->save();
-
+if ($thing_name !== '') {
+  // store the edited name
+  $things->db[$record_idx]->nuance($thing_name);
+  $things->save();
+}
 $effort->whatToShowNext($thing_id);
 ?>

--- a/show-thing.php
+++ b/show-thing.php
@@ -127,8 +127,11 @@ $dialog->choice_add('>', 'Break link to (' . $were_looking_at_tag . ') ' .
 // now show the dialog
 $dialog->title = $thing_type . ' #' . $thing_id;
 $dialog->menu = $thing_text;
+$dialog->show_cancel = false;
 $output = $dialog->show();
 
 // and now link the thing back to the original thing
-$effort->whatToShowNext($output);
+if ($output !== '') {
+  $effort->whatToShowNext($output);
+}
 ?>


### PR DESCRIPTION
Properly handle dialog(1) cancel arriving from user - mostly go back to show screen prior to this one.
Main menu - show-thing.php - now has cancel excluded. ESC can still be used