### PR TITLE
Updates to handle unicode

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,10 @@ Design
 			    shell_exec() calls to the api)
        - or.sh		    (main entry point)
        - /tmp/effort02/	    Variety files used for transferring state
-
+       - pics/		    Pictures for the manual
+       - scrapes/	    Raw & processed data scraped from sites
+       - gexf/		    Network maps in XML form of node & edges
+       - manual/	    Documentation
 
 or.sh <project name>
 Main entry point for using Original Research. The project name if not
@@ -32,8 +35,6 @@ The db directory contains continuing state: a number of flat files
 that contained serialised objects. These are used instead of an SQL
 database at this point.
 
-
-/data/<project>/db/
 - things.serialised
   The Things are entities that we're keeping data about: people,
   podcasts, etc. We also keep data about who uploaded it (only me
@@ -44,10 +45,6 @@ database at this point.
   keep track of when was the last time that a Thing was automatically
   processed, as if it hasn't changed since, there may be no need to
   process it again.
-- akas.serialised
-  A thing may be an alternate name for the same underlying entity:
-  for instance "Del Boy" might turn out to refer to "Derrick Trotter".
-  This file maintains which tags are aka's of another.
 - reviews.serialised
   As we research we might reach our own opinion on something: the
   reviews maintain those notes. We can also leave an empty review
@@ -56,7 +53,8 @@ database at this point.
 - links.serialised
   Two different entities might be linked: for instance Alice appeared
   in a YouTube video. The tags for Alice and the video appear
-  together in this file.
+  together in this file. Data is stored as a triple: subject, predicate and
+  object.
 
 
 /api

--- a/add-review.php
+++ b/add-review.php
@@ -6,6 +6,8 @@
   The user wants to add a review with description
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/reviews_class.php');
@@ -19,22 +21,23 @@ if ($argc !== 4) {
   $effort->file(__FILE__, "expected three arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $tempfile = $argv[2];
   $record_to_show = $argv[3];
+  $esc_record_to_show = escapeshellarg($record_to_show);
 }
 
-$uploader = STANDARD_USER;
-$review_ts = strval(date(TIMESTAMP_FORMAT));
+$uploader = escapeshellarg(STANDARD_USER);
+$review_ts = escapeshellarg(strval(date(TIMESTAMP_FORMAT)));
 
 // Get the review from the user
 $dialog->sizes_change(MENU_SZ_SHORT);
 $dialog->edit = $tempfile;
-$review_text = trim($dialog->show());
+$review_text = escapeshellarg(trim($dialog->show()));
 
 if ($review_text !== '') {
-  shell_exec("php api/review_add.php \"$projname\" \"$review_ts\" " .
-	     "\"$uploader\" \"$review_text\" \"$record_to_show\"");
+  shell_exec("php api/review_add.php $projname $review_ts " .
+	     "$uploader $review_text $esc_record_to_show");
 }
 $effort->whatToShowNext($record_to_show);
 ?>

--- a/api/link_add.php
+++ b/api/link_add.php
@@ -6,6 +6,8 @@
   Entry point for CLI requests to add a simple link
  */
 
+mb_internal_encoding("UTF-8");
+
 require_once('classes/effort02_class.php');
 require_once('classes/links_class.php');
 
@@ -17,7 +19,7 @@ if ($argc !== 5) {
   $effort->err(__FILE__, "expected four arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $subject = $argv[2];
   $predicate = $argv[3];
   $object = $argv[4];

--- a/api/link_edit.php
+++ b/api/link_edit.php
@@ -6,6 +6,8 @@
   Entry point for CLI requests to edit a simple link
  */
 
+mb_internal_encoding("UTF-8");
+
 require_once('classes/effort02_class.php');
 require_once('classes/links_class.php');
 
@@ -17,7 +19,7 @@ if ($argc !== 5) {
   $effort->err(__FILE__, "expected four arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $subject = $argv[2];
   $predicate = $argv[3];
   $object = $argv[4];

--- a/api/review_add.php
+++ b/api/review_add.php
@@ -6,6 +6,8 @@
   Entry point for CLI calls to add a simple Review
  */
 
+mb_internal_encoding("UTF-8");
+
 require_once('classes/effort02_class.php');
 require_once('classes/reviews_class.php');
 
@@ -17,7 +19,7 @@ if ($argc !== 6) {
   $effort->err(__FILE__, "expected five arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $ts = $argv[2];
   $user = $argv[3];
   $text = $argv[4];

--- a/api/thing_add.php
+++ b/api/thing_add.php
@@ -6,6 +6,9 @@
   Entry point for CLI calls to add a simple Thing
  */
 
+mb_internal_encoding("UTF-8");
+
+require_once('defines.php');
 require_once('classes/effort02_class.php');
 require_once('classes/things_class.php');
 
@@ -14,10 +17,10 @@ $effort = new effort02;
 // What we're searching for and what we'll link it to
 $rv = 1;
 if ($argc !== 9) {
-  $effort->err(__FILE__, "expected seven arguments");
+  $effort->err(__FILE__, "expected eight arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $type = $argv[2];
   $tag = $argv[3];
   $ts = $argv[4];
@@ -27,7 +30,7 @@ if ($argc !== 9) {
   $dupes = $argv[8];
 
   $observing_duplicates = false;
-  if (strtolower($dupes) === 'dupes-ok') {
+  if (strtolower($dupes) === DUPES_NOT_OK) {
     $observing_duplicates = true;
   }
 

--- a/automated_scripts/developers_tend_to_have_repos.php
+++ b/automated_scripts/developers_tend_to_have_repos.php
@@ -17,6 +17,8 @@
 // argv[1] will contain a pathandfile that contains the arguments to look at,
 // OR is "ALL".
 
+mb_internal_encoding("UTF-8");
+
 require_once('classes/effort02_class.php');
 require_once('classes/links_class.php');
 require_once('classes/things_class.php');
@@ -31,7 +33,7 @@ if ($argc !== 3) {
   exit;
 }
 
-$projname = $argv[1];
+$projname = escapeshellarg($argv[1]);
 $paf = $argv[2];
 
 if ($rv === 0) {

--- a/automated_scripts/mandatory-connect-urls-to-things.php
+++ b/automated_scripts/mandatory-connect-urls-to-things.php
@@ -11,6 +11,8 @@
   to each in turn.
  */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/effort02_class.php');
 
@@ -26,22 +28,25 @@ $cribs = array(TWITTER_ROOT => 'Twitter',
 	       );
 
 if ($argc === 2) {
-  $projname = $argv[1];
-  $tag_arg = 'ALL';
+  $projname = escapeshellarg($argv[1]);
+  $tag_arg = escapeshellarg('ALL');
 
 } elseif ($argc === 3) {
-  $projname = $argv[1];
-  $taglist = $argv[2];
+  $projname = escapeshellarg($argv[1]);
+  $taglist = escapeshellarg($argv[2]);
   $temp = tmpfile();
   $tag_arg = stream_get_meta_data($temp)['uri'];
+  $esc_tag_arg = escapeshellarg($tag_arg);
   file_put_contents($tag_arg, $taglist);
-
 } else {
   $effort->err(__FILE__, "expected one or two arguments");
 }
 
 foreach($cribs as $url => $thing) {
-  $output = shell_exec('php automated_scripts/template-url-connects-to-thing.php "' . $projname . '" ' . $tag_arg .  ' "' . $thing . '" "' . $url . '"');
+  $esc_url = escapeshellarg($url);
+  $esc_thing = escapeshellarg($thing);
+  $output = shell_exec("php automated_scripts/template-url-connects-to-thing.php " .
+		       "$projname $esc_tag_arg $esc_thing $esc_url");
 }
 
 ?>

--- a/automated_scripts/scrape-hive.one.php
+++ b/automated_scripts/scrape-hive.one.php
@@ -11,9 +11,11 @@
   4. Place in source file ./scrapes/hive.one.input
   5. Remove items from start down to but excluding name 1 (Adam Back)
   6. Remove items from "HIVE" down (short copy) or "End of list" down
-     (long copy)
+  (long copy)
   7. Run this script
 */
+
+mb_internal_encoding("UTF-8");
 
 require_once('defines.php');
 require_once('classes/effort02_class.php');
@@ -21,16 +23,6 @@ require_once('classes/things_class.php');
 require_once('classes/links_class.php');
 
 $effort = new effort02;
-
-//
-// Needed here as some use unicode in their twitter handles
-// https://stackoverflow.com/a/38996494
-// '$' removed to assist
-function convert_to_normal_text($text) {
-  $normal_characters = "a-zA-Z0-9\s`~!@#%^&*()_+-={}|:;<>?,.\/\"\'\\\[\]";
-  $normal_text = preg_replace("/[^$normal_characters]/", '', $text);
-  return $normal_text;
-}
 
 $source = file_get_contents('./scrapes/hive.one.input');
 
@@ -40,7 +32,7 @@ if ($argc !== 2) {
   exit;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
 }
 
 $things = new things($projname);
@@ -50,61 +42,67 @@ while(strlen($source) > 0) {
   list($rank, $person, $handle, $score, $following, $followers, $change,
        $rest) =
     explode("\n", $source, 8);
-  $name = trim(convert_to_normal_text($person));
+  $name = trim($person);
 
+  // Add twitter handle to database if we don't already have it. If we DO have
+  // it, make sure it's connected to the Twitter thing etc
   $twitter_url = TWITTER_ROOT . trim(trim($handle), '@');
   $ttr_existing_tag = $things->getTagFor($twitter_url);
   if ($ttr_existing_tag === false) {
-    $ttr_thing_type = TYPE_TEST_THING;
-    $ttr_thing_ts = date(TIMESTAMP_FORMAT);
-    $ttr_thing_uploader = STANDARD_USER;
-    $ttr_thing_name = $twitter_url;
-    $ttr_thing_nuance = '';
-    $ttr_thing_tag = $things->getNewTag($ttr_thing_name);
+    $ttr_thing_type = escapeshellarg(TYPE_TEST_THING);
+    $ttr_thing_ts = escapeshellarg(date(TIMESTAMP_FORMAT));
+    $ttr_thing_uploader = escapeshellarg(STANDARD_USER);
+    $ttr_thing_name = escapeshellarg($twitter_url);
+    $ttr_thing_nuance = escapeshellarg('');
+    $ttr_thing_tag = escapeshellarg($things->getNewTag($ttr_thing_name));
+    $predicate = escapeshellarg(DUPES_NOT_OK);
 
-    shell_exec("php api/thing_add.php \"$projname\" \"$ttr_thing_type\" " .
-	       "\"$ttr_thing_tag\" \"$ttr_thing_ts\" " .
-	       "\"$ttr_thing_uploader\" \"$ttr_thing_name\" " .
-	       "\"$ttr_thing_nuance\" \"dupes-not-ok\"");
+    shell_exec("php api/thing_add.php $projname $ttr_thing_type " .
+	       "$ttr_thing_tag $ttr_thing_ts $ttr_thing_uploader " .
+	       "$ttr_thing_name $ttr_thing_nuance $predicate");
     $things->load();
     shell_exec("php automated_scripts/mandatory-connect-urls-to-things.php " .
-	       "\"$projname\" \"$ttr_thing_tag\"");
+	       "$projname $ttr_thing_tag");
 
   } else {
     $ttr_thing_tag = $ttr_existing_tag;
     shell_exec("php automated_scripts/mandatory-connect-urls-to-things.php " .
-	       "\"$projname\" \"$ttr_thing_tag\"");
+	       "$projname $ttr_thing_tag");
   }
 
   // Do we already have this guys proper name?
-  $people_tag = $things->getTagFor('People');
-  $existing_name_tag = $things->getTagFor($name);
+  $people_tag = escapeshellarg($things->getTagFor('People'));
+  $existing_name_tag = escapeshellarg($things->getTagFor($name));
   if ($existing_name_tag === false) {
     // Tag not found.
     print_r("DIY -- Don't have exact match for '$name' - DIY\n");
     // add a thing under this name, and link it in
     // 1. add in the name as thing we dont already have, get back its tag
-    $newname_thing_type = TYPE_TEST_THING;
-    $newname_thing_ts = date(TIMESTAMP_FORMAT);
-    $newname_thing_uploader = STANDARD_USER;
-    $newname_thing_name = $name;
-    $newname_thing_nuance = '';
-    $newname_thing_tag = $things->getNewTag($newname_thing_name);
+    $newname_thing_type = escapeshellarg(TYPE_TEST_THING);
+    $newname_thing_ts = escapeshellarg(date(TIMESTAMP_FORMAT));
+    $newname_thing_uploader = escapeshellarg(STANDARD_USER);
+    $newname_thing_name = escapeshellarg($name);
+    $newname_thing_nuance = escapeshellarg('');
+    $newname_thing_tag = escapeshellarg($things->getNewTag($newname_thing_name));
+    $predicate = escapeshellarg(DUPES_NOT_OK);
 
-    $output = shell_exec("php api/thing_add.php \"$projname\" " .
-			 "\"$newname_thing_type\" \"$newname_thing_tag\" " .
-			 "\"$newname_thing_ts\" \"$newname_thing_uploader\" " .
-			 "\"$newname_thing_name\" \"$newname_thing_nuance\"");
+    $output = shell_exec("php api/thing_add.php $projname " .
+			 "$newname_thing_type $newname_thing_tag " .
+			 "$newname_thing_ts $newname_thing_uploader " .
+			 "$newname_thing_name $newname_thing_nuance " .
+			 "$predicate");
+
     $things->load();
     $output = shell_exec("php automated_scripts/mandatory-connect-urls-to-things.php " .
-			 "\"$projname\" \"$newname_thing_tag\"");
+			 "$projname $newname_thing_tag");
+    $predicate = escapeshellarg(PREDICATE_LINKS);
 
     // 2. link that tag to the twitter link received above
-    shell_exec("php api/link_add.php \"$projname\" \"$ttr_thing_tag\" " .
-	       PREDICATE_LINKS  . " \"$newname_thing_tag\"");
+    shell_exec("php api/link_add.php $projname $ttr_thing_tag $predicate  " .
+	       "$newname_thing_tag");
     // And also link that new name to the People tag
-    shell_exec("php api/link_add.php \"$projname\" \"$people_tag\" " .
-	       PREDICATE_LINKS  . " \"$newname_thing_tag\"");
+    shell_exec("php api/link_add.php $projname $people_tag $predicate " .
+	       "$newname_thing_tag");
 
     // 3. Does the twitter handle we have already itself link to someone who is
     //    linked to People? If so, this newname we just added is probably an
@@ -124,8 +122,12 @@ while(strlen($source) > 0) {
       $links2db = $links->filter($link1);
       foreach($links2db as $link2) {
 	if ($link2 === $people_tag) {
-	  shell_exec("php api/link_add.php \"$projname\" \"$link1\" " .
-		     PREDICATE_AKA_OF . " \"$newname_thing_tag\"");
+	  if ($link1 !== $newname_thing_tag) {
+	    $esc_link1 = escapeshellarg($link1);
+	    $predicate = escapeshellarg(PREDICATE_AKA_OF);
+	    shell_exec("php api/link_add.php $projname $esc_link1 $predicate " .
+		       "$newname_thing_tag");
+	  }
 	}
       }
     }
@@ -134,10 +136,11 @@ while(strlen($source) > 0) {
     // Tag IS found.
     // As we already have the link, this call will ultimately return having
     // not added the link
-    shell_exec("php api/link_add.php \"$projname\" \"$existing_name_tag\" " .
-	       PREDICATE_LINKS  . " \"$people_tag\"");
-    shell_exec("php api/link_add.php \"$projname\" \"$existing_name_tag\" " .
-	       PREDICATE_LINKS  . " \"$ttr_thing_tag\"");
+    $predicate = escapeshellarg(PREDICATE_LINKS);
+    shell_exec("php api/link_add.php $projname $existing_name_tag " .
+	       "$predicate $people_tag");
+    shell_exec("php api/link_add.php $projname $existing_name_tag " .
+	       "$predicate $ttr_thing_tag");
   }
   print_r($rank . ' ' . $twitter_url . ' ' . $name . ' ' . "\n");
 

--- a/automated_scripts/template-url-connects-to-thing.php
+++ b/automated_scripts/template-url-connects-to-thing.php
@@ -17,6 +17,8 @@
 // argv[1] will contain a pathandfile that contains the arguments to look at,
 // or is "ALL".
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/effort02_class.php');
 require_once('classes/links_class.php');
@@ -34,7 +36,7 @@ if ($argc !== 5) {
 }
 
 $tag_arr = array();
-$projname = $argv[1];
+$projname = escapeshellarg($argv[1]);
 $paf = $argv[2];
 $tagname = $argv[3]; // eg, Twitter
 $urlroot = $argv[4]; // eg, https://twitter.com
@@ -69,15 +71,16 @@ if ($rv === 0) {
   $thingtag = $things->getTagFor($tagname);
   if ($thingtag === false) {
     // Can't find the tag? This is a new database so add it in
-    $thing_type = TYPE_TEST_THING;
-    $thing_ts = date(TIMESTAMP_FORMAT);
-    $thing_uploader = STANDARD_USER;
-    $thing_name = $tagname;
-    $thing_nuance = '';
-    $thing_tag = $things->getNewTag($thing_name);
-    shell_exec("php api/thing_add.php \"$projname\" \"$thing_type\" " .
-	       "\"$thing_tag\" \"$thing_ts\" \"$thing_uploader\" " .
-	       "\"$thing_name\" \"$thing_nuance\" \"dupes-not-ok\"");
+    $thing_type = escapeshellarg(TYPE_TEST_THING);
+    $thing_ts = escapeshellarg(date(TIMESTAMP_FORMAT));
+    $thing_uploader = escapeshellarg(STANDARD_USER);
+    $thing_name = escapeshellarg($tagname);
+    $thing_nuance = escapeshellarg('');
+    $thing_tag = escapeshellarg($things->getNewTag($thing_name));
+    $dupes = escapeshellarg(DUPES_NOT_OK);
+    shell_exec("php api/thing_add.php $projname $thing_type " .
+	       "$thing_tag $thing_ts $thing_uploader " .
+	       "$thing_name $thing_nuance $dupes");
     $thingtag = $thing_tag;
   }
 
@@ -96,7 +99,7 @@ if ($rv === 0) {
       if ($tag_last_checked === null ||
 	  $tag_last_checked <= $thing->timestamp()) {;
 	$automated_cribs->setTagLastChecked($tag, $thing->timestamp());
-	if (strpos($thing->text(), $urlroot) !== false) {
+	if (mb_strpos($thing->text(), $urlroot) !== false) {
 	  if ($links->linkTags($tag, PREDICATE_LINKS, $thingtag) == 0)
 	    $changes++;
 	}

--- a/break-link.php
+++ b/break-link.php
@@ -7,6 +7,8 @@
   links database.
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/links_class.php');
 require_once('classes/effort02_class.php');
@@ -19,7 +21,7 @@ if ($argc !== 4) {
   exit;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $arg_from = $argv[2];
   $arg_to = $argv[3];
 }

--- a/classes/automated_cribs_class.php
+++ b/classes/automated_cribs_class.php
@@ -37,6 +37,7 @@ class automated_cribs
   public $db;
 
   function automated_cribs($projname) {
+    $projname = mb_substr($projname, 1, mb_strlen($projname) - 2);
     $this->db_file = './data/' . $projname . '/db/automated_cribs.serialised';
   }
 

--- a/classes/links_class.php
+++ b/classes/links_class.php
@@ -36,6 +36,7 @@ class links
   public $db;
 
   function links($projname) {
+    $projname = mb_substr($projname, 1, mb_strlen($projname) - 2);
     $this->db_file = './data/' . $projname . '/db/links.serialised';
   }
 

--- a/classes/reviews_class.php
+++ b/classes/reviews_class.php
@@ -57,6 +57,7 @@ class reviews
   public $db;
 
   function reviews($projname) {
+    $projname = mb_substr($projname, 1, mb_strlen($projname) - 2);
     $this->db_file = './data/' . $projname . '/db/reviews.serialised';
   }
 

--- a/classes/things_class.php
+++ b/classes/things_class.php
@@ -73,7 +73,7 @@ class thing
    */
   function textIs($phrase, $things, $links) {
     $rv = array();
-    if ($phrase === strtolower($this->text())) {
+    if ($phrase === mb_strtolower($this->text())) {
       $rv[] = $this;
     }
     return $rv;
@@ -84,7 +84,7 @@ class thing
     foreach($links_db as $link_tag) {
       $aka = $things->getThingFromTag($link_tag);
 
-      if ($phrase === strtolower($aka->text())) {
+      if ($phrase === mb_strtolower($aka->text())) {
 	$rv[] = $this;
       }
     }
@@ -92,7 +92,7 @@ class thing
   }
 
   function textStrPos($phrase) {
-    $pos = strpos(strtolower($this->text()), $phrase);
+    $pos = mb_strpos(mb_strtolower($this->text()), $phrase);
     if ($pos !== false) {
       return array($this);
     }
@@ -106,6 +106,7 @@ class things
   public $db;
 
   function things($projname) {
+    $projname = mb_substr($projname, 1, mb_strlen($projname) - 2);
     $this->db_file = './data/' . $projname . '/db/things.serialised';
   }
 
@@ -141,7 +142,7 @@ class things
   function getTagFor($text, $lower = false) {
     if ($lower === true) {
       foreach($this->db as $thing) {
-	if (strtolower($thing->text()) === $text) {
+	if (mb_strtolower($thing->text()) === $text) {
 	  return $thing->tag();
 	}
       }
@@ -170,12 +171,19 @@ class things
   // Also exclude website prefixes
   function getNewTag($text) {
     $s = str_replace(' ', '', $text);
-    if (strpos($s, 'https://www.') === 0) {
-      $s = substr($s, 12, 3);
-    } elseif (strpos($s, 'https://') === 0) {
-      $s = substr($s, 8, 3);
+    if (mb_strpos($s, 'https://www.') === 0) {
+      $s = mb_substr($s, 12, 3);
+    } elseif (mb_strpos($s, 'https://') === 0) {
+      $s = mb_substr($s, 8, 3);
     } else {
-      $s = substr($s, 0, 3);
+      $index = -1;
+      do {
+	$index++;
+      } while ($index < mb_strlen($s)
+	       &&
+	       ($s[$index] === "'" || $s[$index] === '"')
+	       );
+      $s = mb_substr($s, $index, 3);
     }
     $s .= dechex(sizeof($this->db) + 1);
     return $s;

--- a/connect-as-aka.php
+++ b/connect-as-aka.php
@@ -7,6 +7,8 @@
   Thing, cause $subject to become an AKA of $object.
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -22,23 +24,30 @@ if ($argc === 3) {
   $thing_to_add_to = 0;
 
 } else {
-  $projname = $argv[1];
-  $subject = $argv[2];
+  $projname = escapeshellarg($argv[1]);
+  $subject = escapeshellarg($argv[2]);
   $object = $argv[3];
+  $esc_object = escapeshellarg($object);
 }
 
 // AKA it in
 $links = new links($projname);
 $links->load();
 $found = false;
+$predicate = escapeshellarg(PREDICATE_AKA_OF);
 foreach($links->db as $item) {
   if (($item->subject() === $object && $item->object() === $subject)
       ||
       ($item->object() === $object && $item->subject() === $subject)) {
-    shell_exec("php api/link_edit.php \"$projname\" \"$subject\" " .
-	       PREDICATE_AKA_OF . " \"$object\"");
+    shell_exec("php api/link_edit.php $projname $subject $predicate " .
+	       "$esc_object");
+    $found = true;
     break;
   }
+}
+if ($found === false) {
+  shell_exec("php api/link_add.php $projname $subject $predicate " .
+	     "$esc_object");
 }
 
 // Next show the object of the AKA

--- a/defines.php
+++ b/defines.php
@@ -15,4 +15,7 @@ define("PREDICATE_LINKS", 0);
 define("PREDICATE_AKA_OF", 1);
 
 define("TWITTER_ROOT", 'https://twitter.com/');
+
+define("DUPES_OK", 'dupes-ok');
+define("DUPES_NOT_OK", 'dupes-not-ok');
 ?>

--- a/delete-thing.php
+++ b/delete-thing.php
@@ -6,6 +6,8 @@
   Given thing N, allow user to edit its name
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -19,7 +21,7 @@ if ($argc !== 3) {
   $effort->err(__FILE__, "expected three arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $record_to_delete = $argv[2];
 }
 

--- a/edit-nuance.php
+++ b/edit-nuance.php
@@ -6,6 +6,8 @@
   Given thing N, allow user to edit the associated nuance
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -19,7 +21,7 @@ if ($argc !== 3) {
   $effort->err(__FILE__, "expected two arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $record_to_show = $argv[2];
 }
 

--- a/edit-thing.php
+++ b/edit-thing.php
@@ -6,6 +6,8 @@
   Given thing N, allow user to edit its name
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -19,7 +21,7 @@ if ($argc !== 3) {
   $effort->err(__FILE__, "expected two arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $record_to_show = $argv[2];
 }
 

--- a/manual_scripts/display-or-words.php
+++ b/manual_scripts/display-or-words.php
@@ -16,6 +16,8 @@
 // identify it.
 define("DIVIDER", "---abc123---\n");
 
+mb_internal_encoding("UTF-8");
+
 require_once('classes/things_class.php');
 require_once('classes/effort02_class.php');
 
@@ -32,7 +34,7 @@ if ($argc !== 2) {
   exit;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
 }
 
 // Get the entries: we want the text in lower case
@@ -40,9 +42,9 @@ $things = new things($projname);
 $things->load();
 $p = array();
 foreach($things->db as $thing) {
-  if (substr($thing->text(), 0, strlen('https://')) === 'https://'
+  if (mb_substr($thing->text(), 0, mb_strlen('https://')) === 'https://'
       ||
-      substr($thing->text(), 0, strlen('http://')) === 'http://') {
+      mb_substr($thing->text(), 0, mb_strlen('http://')) === 'http://') {
     $p[] = $thing->text();
   } else {
     $p[] = strtolower($thing->text());

--- a/manual_scripts/export-to-html.php
+++ b/manual_scripts/export-to-html.php
@@ -6,6 +6,8 @@
   Dump the database to html
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/things_class.php');
 require_once('classes/links_class.php');
@@ -19,7 +21,7 @@ if ($argc !== 3) {
   exit;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $destdir = $argv[2];
 }
 

--- a/manual_scripts/interesting.php
+++ b/manual_scripts/interesting.php
@@ -23,6 +23,8 @@
   -d test -o /tmp/or-words
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/things_class.php');
 require_once('classes/effort02_class.php');
@@ -37,9 +39,9 @@ $source_paf = '';
 // Retrieve command line options
 $options = getopt('d:o:s::', array('db:', 'or-words:', 'source::'));
 if (array_key_exists('d', $options))
-  $db = $options['d'];
+  $db = escapeshellarg($options['d']);
 if (array_key_exists('db', $options))
-  $db = $options['db'];
+  $db = escapeshellarg($options['db']);
 if (array_key_exists('o', $options))
   $or_paf = $options['o'];
 if (array_key_exists('or-words', $options))
@@ -60,7 +62,7 @@ if (!file_exists($or_paf)) {
 // Handle optional arguments
 // Specifically, draw the source in either way it's provided
 if (!file_exists($source_paf)) {
-  $source1 = trim(strtolower(stream_get_contents(STDIN)));
+  $source1 = trim(mb_strtolower(stream_get_contents(STDIN)));
   if ($source1 === FALSE) {
     exit("Unable to get STDIN\n");
   }
@@ -69,9 +71,9 @@ if (!file_exists($source_paf)) {
   }
 
 } else {
-  $source1 = trim(strtolower(file_get_contents($source_paf)));
+  $source1 = trim(mb_strtolower(file_get_contents($source_paf)));
 }
-if (strlen($source1) === 0) {
+if (mb_strlen($source1) === 0) {
   exit("Source cannot be of zero length\n");
 }
 
@@ -81,10 +83,10 @@ $source2 = str_replace("’", "'", $source1);
 // Draw in and clean the OR words which describe all the words and phrases we
 // might be interested in
 if ($or_paf !== '') {
-  $or_skiplist = strtolower(file_get_contents($or_paf));
+  $or_skiplist = mb_strtolower(file_get_contents($or_paf));
   // The first line of the OR skiplist defines the delimiter used throughout
-  $or_skiplist_delim = trim(substr($or_skiplist, 0,
-				   strpos($or_skiplist, "\n")));
+  $or_skiplist_delim = trim(mb_substr($or_skiplist, 0,
+				      mb_strpos($or_skiplist, "\n")));
   $or_skiplist = str_replace("’", "'", $or_skiplist);
   $or_skiplist_arr1 = explode($or_skiplist_delim, $or_skiplist);
 
@@ -94,7 +96,7 @@ if ($or_paf !== '') {
 $or_skiplist_arr2 = array();
 foreach($or_skiplist_arr1 as $orword) {
   $v = trim($orword);
-  if (strlen($v) > 0) {
+  if (mb_strlen($v) > 0) {
     $or_skiplist_arr2[] = $v;
   }
 }
@@ -141,7 +143,7 @@ foreach($display_arr1 as $candidate) {
     // Then this is not an AKA
     $display = $candidate;
   }
-  $display_arr2[] = strtolower($display);
+  $display_arr2[] = mb_strtolower($display);
 }
 
 // Roll up duplicates

--- a/mark-reviewed.php
+++ b/mark-reviewed.php
@@ -6,6 +6,8 @@
   The user wants to add a review withOUT a description
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/reviews_class.php');
 require_once('classes/effort02_class.php');
@@ -17,17 +19,19 @@ if ($argc !== 4) {
   $effort->err(__FILE__, "expected three arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $tempfile = $argv[2];
   $record_to_show = $argv[3];
+  $esc_record_to_show = escapeshellarg($record_to_show);
 }
 
-$uploader = STANDARD_USER;
-$review_ts = strval(date(TIMESTAMP_FORMAT));
+$uploader = escapeshellarg(STANDARD_USER);
+$review_ts = escapeshellarg(strval(date(TIMESTAMP_FORMAT)));
 
 // There is no review: we are only marking this as reviewed
-$review_text = '';
+$review_text = escapeshellarg('');
 
-shell_exec("php api/review_add.php \"$projname\" \"$review_ts\" \"$uploader\" \"$review_text\" \"$record_to_show\"");
+shell_exec("php api/review_add.php $projname $review_ts $uploader $review_text ".
+	   "$esc_record_to_show");
 $effort->whatToShowNext($record_to_show);
 ?>

--- a/search.php
+++ b/search.php
@@ -7,6 +7,8 @@
   to him the results of it
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -25,7 +27,7 @@ if ($argc === 2) {
   $thing_to_search_for = 0;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $thing_to_search_for = $argv[2];
 }
 
@@ -48,7 +50,7 @@ if ($search_phrase === '') {
   $found_arr = array();
   $exact_arr = array();
   $exact_tag_arr = array();
-  $lsearch_phrase = strtolower($search_phrase);
+  $lsearch_phrase = mb_strtolower($search_phrase);
   foreach($things->db as $item) {
     $exact_arr2 = $item->textIs($lsearch_phrase, $things, $links);
     $found_arr2 = $item->textStrPos($lsearch_phrase);
@@ -59,7 +61,7 @@ if ($search_phrase === '') {
     } elseif (sizeof($found_arr2) > 0) {
       $found_arr = array_merge($found_arr, $found_arr2);
     }
-    $tag = strtolower($item->tag());
+    $tag = mb_strtolower($item->tag());
     if ($tag === $lsearch_phrase)
       $exact_tag_arr[] = $item;
   }

--- a/show-reviews.php
+++ b/show-reviews.php
@@ -6,6 +6,8 @@
   Given a particular tag, display all the reviews associated with it.
 */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/reviews_class.php');
@@ -20,7 +22,7 @@ if ($argc !== 3) {
   $effort->err(__FILE__, "expected two arguments");
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $record_to_show = $argv[2];
 }
 

--- a/show-thing.php
+++ b/show-thing.php
@@ -6,6 +6,8 @@
   Call up a Thing and display it, along with such menus as required
  */
 
+mb_internal_encoding("UTF-8");
+
 require_once('defines.php');
 require_once('classes/dialog_common.php');
 require_once('classes/things_class.php');
@@ -21,7 +23,7 @@ if ($argc !== 3) {
   $record_to_show = 0;
 
 } else {
-  $projname = $argv[1];
+  $projname = escapeshellarg($argv[1]);
   $record_to_show = $argv[2];
 }
 
@@ -103,8 +105,8 @@ if (sizeof($connections) !== 0) {
     }
     $n++;
   }
-  if (strlen($akas_text) > 0) {
-    $akas_text = ' aka:[' . substr($akas_text, 0, -2) . '] ';
+  if (mb_strlen($akas_text) > 0) {
+    $akas_text = ' aka:[' . mb_substr($akas_text, 0, -2) . '] ';
   }
   $dialog->choice_add('?', 'Top Level');
 } else {


### PR DESCRIPTION
UTF-8 now made default internal encoding throughout
Modify to use mb_* functions where possible, adapting when can't
Anything being passed to shell_exec() is now escaped
' and " excluded from tag construction
GEXF now removes self-referring links, and looks for orphan links later
Minor README addition